### PR TITLE
docs(gswarm): source should include $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ sudo rm -rf /usr/local/go
 curl -L https://go.dev/dl/go1.22.4.linux-amd64.tar.gz | sudo tar -xzf - -C /usr/local
 echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' >> $HOME/.bash_profile
 echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> $HOME/.bash_profile
-source .bash_profile
+source $HOME/.bash_profile
 go version
 ```
 ```


### PR DESCRIPTION
Not sure if this is a typo or not, but it's not working with `source .bash_profile`